### PR TITLE
fixed 2 typos

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,7 +26,7 @@ This challenge requires HTTP API calls when a user adds a consent or to populate
 What we recommend is to implement the calls as standard HTTP requests to a REST API with the following specification:
 
  - `GET /consents`: Returns a list of consents along with pagination data.
- - `POST /consent`: Add a new consent.
+ - `POST /consents`: Add a new consent.
 
 You can then mock the HTTP calls by mocking the `XMLHttpRequest` object or the `fetch` method in the browser. The mock should have a pre-populated list of objects and add a new object to the list when a `POST` request is sent.
 

--- a/technical-consultant/README.md
+++ b/technical-consultant/README.md
@@ -17,7 +17,7 @@ This challenge is composed of 3 steps:
 
 One of the key requirements of GDPR is that user consent is needed before personal data is used for any purpose like targeted advertising, personalization, analytics, etc. One of the tools that Didomi offers to comply with this requirement is "consent notices".
 
-A consent notice asks the user for consent to a set of purposes (what will the collected personal data be used for) and vendors (who will collect personal data). It can be a small banner at the top or bottom of a website or mobile app, a full-screen popin, etc.
+A consent notice asks the user for consent to a set of purposes (what will the collected personal data be used for) and vendors (who will collect personal data). It can be a small banner at the top or bottom of a website or mobile app, a full screen popin, etc.
 
 Using the [Getting Started](https://developers.didomi.io/cmp/web-sdk/getting-started) section of the Didomi documentation, create an HTML page that displays a consent notice to collect consent from the user.  
 You can use the following API key for your notice: **89a1965c-e470-462e-9467-6132bb46ab94**.


### PR DESCRIPTION
1. `consent` -> `consents`

2. `full-screen` -> `full screen`
> As an adjective or when describing a mode or setting "fullscreen" or "full-screen" should be used. As a noun or when describing anything that is occupying the entire display or screen, "full screen" should be used.
https://www.computerhope.com/jargon/f/fullscre.htm